### PR TITLE
Explicitely set a parent in ParamProcessor to avoid an error with Spoon 5.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
     		<groupId>fr.inria.gforge.spoon</groupId>
 			<artifactId>spoon-core</artifactId>
-			<version>5.5.0-SNAPSHOT</version>
+			<version>5.6.0-SNAPSHOT</version>
 		</dependency>
 <dependency>
 	<groupId>org.apache.commons</groupId>

--- a/src/main/java/bcu/transformer/processors/ParamProcessor.java
+++ b/src/main/java/bcu/transformer/processors/ParamProcessor.java
@@ -50,6 +50,7 @@ public class ParamProcessor extends AbstractProcessor<CtInvocation<?>> {
 			invoc.setArguments(Arrays.asList(new CtExpression[]{param,arg,location}));
 			execref.setActualTypeArguments(Arrays.asList(new CtTypeReference<?>[]{tmpref}));
 
+			invoc.setParent(arg0);
 			// fail
 			// param.replace(invoc);
 


### PR DESCRIPTION
Fix a bug with Spoon 5.6.0 spotted there: https://github.com/INRIA/spoon/issues/1207