### PR TITLE
Use OW2 snapshot repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,9 @@
 
 <repositories>
     <repository>
-        <id>gforge.inria.fr-snapshot</id>
-        <name>Maven Repository for Spoon Snapshot</name>
-        <url>http://maven.inria.fr/artifactory/spoon-public-snapshot/</url>
+        <id>ow2.org-snapshot</id>
+        <name>Maven Repository for Spoon Snapshots</name>
+        <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
         <snapshots />
     </repository>
 </repositories>


### PR DESCRIPTION
Hi!

We run Casper in Spoon's CI, and currently it only pulls beta versions as the snapshot repository is out of date. We could inject the correct snapshot repository into the pom, but just updating it here is much easier, so this PR simply sets the new snapshot repo in the pom :)

See inria/spoon#3775